### PR TITLE
Cashflow Management and Variant Management Tickets Issue Resolved

### DIFF
--- a/src/pages/cash-flow/Cash-Flow.vue
+++ b/src/pages/cash-flow/Cash-Flow.vue
@@ -152,6 +152,7 @@
                 </q-tooltip></q-btn
               >
               <q-btn
+                v-if="props.row.transactionDate > formattedUndoDate"
                 icon="undo"
                 dense
                 flat
@@ -228,6 +229,8 @@ const showUndoCashFlowModal = ref(false);
 const timeStamp = Date.now();
 const formattedToDate = date.formatDate(timeStamp, 'YYYY-MM-DD');
 const past5Date = date.subtractFromDate(timeStamp, { date: 5 });
+const past2Date = date.subtractFromDate(timeStamp, { date: 2 });
+const formattedUndoDate = date.formatDate(past2Date, 'YYYY-MM-DD');
 const formattedFromDate = date.formatDate(past5Date, 'YYYY-MM-DD');
 const filter = ref({
   sender: '',
@@ -291,8 +294,6 @@ const handleUndoCashFlow = async (selectedRow: ICashFlowRecords) => {
   showUndoCashFlowModal.value = true;
 };
 const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
-  if (isLoading.value) return;
-  isLoading.value = true;
   try {
     const res = await addCashFlowApi({
       sourceUserId: selectedRow.targetUserId ?? -1,
@@ -305,7 +306,7 @@ const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
         message: res.message,
         color: 'green',
       });
-      getCashFlowRecords();
+      await getCashFlowRecords();
     }
   } catch (e) {
     let message = 'Unexpected Error Occurred Add Cash Flow';
@@ -319,7 +320,6 @@ const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
     });
   }
   showUndoCashFlowModal.value = false;
-  isLoading.value = false;
 };
 const getCashFlowRecords = async (data?: {
   pagination?: Omit<typeof pagination.value, 'rowsNumber'>;

--- a/src/pages/cash-flow/Cash-Flow.vue
+++ b/src/pages/cash-flow/Cash-Flow.vue
@@ -218,7 +218,7 @@ import { cashFlowListApi, addCashFlowApi } from 'src/services';
 import { useAuthStore } from 'src/stores';
 import { isPosError, cashFlowColumn } from 'src/utils';
 import PreviewCashFlow from 'src/components/cash-flow/PreviewCashFlow.vue';
-import UndoCashFlowModal from 'components/return/CompleteOrCancelModal.vue';
+import UndoCashFlowModal from 'src/components/return/CompleteOrCancelModal.vue';
 const authStore = useAuthStore();
 const pageTitle = getRoleModuleDisplayName(
   EUserModules.CashInCashOutManagement
@@ -294,6 +294,8 @@ const handleUndoCashFlow = async (selectedRow: ICashFlowRecords) => {
   showUndoCashFlowModal.value = true;
 };
 const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
+  if (isLoading.value) return;
+  isLoading.value = true;
   try {
     const res = await addCashFlowApi({
       sourceUserId: selectedRow.targetUserId ?? -1,
@@ -306,6 +308,7 @@ const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
         message: res.message,
         color: 'green',
       });
+      isLoading.value = false;
       await getCashFlowRecords();
     }
   } catch (e) {
@@ -319,6 +322,7 @@ const handleAddNewFlow = async (selectedRow: ICashFlowRecords) => {
       icon: 'error',
     });
   }
+  isLoading.value = false;
   showUndoCashFlowModal.value = false;
 };
 const getCashFlowRecords = async (data?: {

--- a/src/pages/return/Today-Sale-Summary.vue
+++ b/src/pages/return/Today-Sale-Summary.vue
@@ -268,7 +268,6 @@ const handleDeleteExpense = async (shopAccountDetailId: number) => {
         type: 'positive',
       });
       updateSaleSummary();
-      showDeleteExpenseModal.value = false;
     }
   } catch (e) {
     let message = 'Unexpected Error Occurred';
@@ -280,5 +279,6 @@ const handleDeleteExpense = async (shopAccountDetailId: number) => {
       type: 'negative',
     });
   }
+  showDeleteExpenseModal.value = false;
 };
 </script>

--- a/src/pages/variant/Variant-Management.vue
+++ b/src/pages/variant/Variant-Management.vue
@@ -332,7 +332,15 @@ const AddNewVariant = () => {
   isVariantModalVisible.value = true;
 };
 const handleManageClick = (id: number, name: string, status: string) => {
-  router.push(`/variant/${name}/${id}/${status}`);
+  if (status === 'InActive') {
+    $q.notify({
+      message: 'InActive Variant (Please change status to Active)',
+      type: 'warning',
+    });
+  }
+  if (status === 'Active') {
+    router.push(`/variant/${name}/${id}/${status}`);
+  }
 };
 const updateOrAddVariant = async (
   name: string,


### PR DESCRIPTION
Cashflow Management: past2Days Condition implemented on Undo Button

And
 
Variant Management:  I have handled it from the frontend only. When the status is InActive, it will show a notification, and if the status is Active, the list page will render. I have applied this condition because no data is coming from the backend in the InActive status. Previously, when clicking on manage, it used to render but with empty content. But now, after this condition, the empty page will not open at all.